### PR TITLE
use lists and make example more accessible

### DIFF
--- a/extensions/custom-footer/src/Extension.jsx
+++ b/extensions/custom-footer/src/Extension.jsx
@@ -3,32 +3,69 @@ import {
   InlineLayout,
   InlineStack,
   Link,
+  ListItem,
   Text,
   useShop,
-} from '@shopify/ui-extensions-react/checkout';
+} from "@shopify/ui-extensions-react/checkout";
 
 // [START custom-footer.render]
 export default function Extension() {
-  const {storefrontUrl} = useShop();
+  const { storefrontUrl } = useShop();
 
   return (
-    <InlineLayout columns={['auto', 'fill']}>
-      <InlineStack spacing="extraTight" blockAlignment="center">
-        <Link to={storefrontUrl}>Home</Link>
-        <Icon source="chevronRight" size="extraSmall" />
-        <Link to={new URL('/collections', storefrontUrl).href}>Shop</Link>
-        <Icon source="chevronRight" size="extraSmall" />
-        <Text appearance="subdued">Checkout</Text>
+    <InlineLayout
+      blockAlignment="center"
+      columns={["auto", "fill"]}
+      accessibilityRole="navigation"
+    >
+      <InlineStack
+        spacing="extraTight"
+        blockAlignment="center"
+        accessibilityRole="orderedList"
+      >
+        <InlineStack
+          accessibilityRole="listItem"
+          blockAlignment="center"
+          spacing="extraTight"
+        >
+          <Link to={storefrontUrl}>Home</Link>
+          <Icon source="chevronRight" size="extraSmall" />
+        </InlineStack>
+        <InlineStack
+          accessibilityRole="listItem"
+          blockAlignment="center"
+          spacing="extraTight"
+        >
+          <Link to={new URL("/collections", storefrontUrl).href}>Shop</Link>
+          <Icon source="chevronRight" size="extraSmall" />
+        </InlineStack>
+        <InlineStack accessibilityRole="listItem">
+          <Text appearance="subdued">Checkout</Text>
+        </InlineStack>
       </InlineStack>
 
-      <InlineStack spacing="tight" inlineAlignment="end">
-        <Link to={new URL('/sizing', storefrontUrl).href}>Sizing</Link>
-        <Link to={new URL('/terms', storefrontUrl).href}>Terms</Link>
-        <Link to={new URL('/privacy', storefrontUrl).href}>Privacy</Link>
-        <Link to={new URL('/faq', storefrontUrl).href}>FAQ</Link>
-        <Link to={new URL('/accessibility', storefrontUrl).href}>
-          Accessibility
-        </Link>
+      <InlineStack
+        spacing="tight"
+        inlineAlignment="end"
+        accessibilityRole="orderedList"
+      >
+        <ListItem>
+          <Link to={new URL("/sizing", storefrontUrl).href}>Sizing</Link>
+        </ListItem>
+        <ListItem>
+          <Link to={new URL("/terms", storefrontUrl).href}>Terms</Link>
+        </ListItem>
+        <ListItem>
+          <Link to={new URL("/privacy", storefrontUrl).href}>Privacy</Link>
+        </ListItem>
+        <ListItem>
+          <Link to={new URL("/faq", storefrontUrl).href}>FAQ</Link>
+        </ListItem>
+        <ListItem>
+          <Link to={new URL("/accessibility", storefrontUrl).href}>
+            Accessibility
+          </Link>
+        </ListItem>
       </InlineStack>
     </InlineLayout>
   );

--- a/extensions/custom-footer/src/Extension.jsx
+++ b/extensions/custom-footer/src/Extension.jsx
@@ -3,14 +3,14 @@ import {
   InlineLayout,
   InlineStack,
   Link,
-  ListItem,
   Text,
+  View,
   useShop,
-} from "@shopify/ui-extensions-react/checkout";
+} from '@shopify/ui-extensions-react/checkout';
 
 // [START custom-footer.render]
 export default function Extension() {
-  const { storefrontUrl } = useShop();
+  const {storefrontUrl} = useShop();
 
   return (
     <InlineLayout
@@ -49,23 +49,23 @@ export default function Extension() {
         inlineAlignment="end"
         accessibilityRole="orderedList"
       >
-        <ListItem>
+        <View accessibilityRole="listItem">
           <Link to={new URL("/sizing", storefrontUrl).href}>Sizing</Link>
-        </ListItem>
-        <ListItem>
+        </View>
+        <View accessibilityRole="listItem">
           <Link to={new URL("/terms", storefrontUrl).href}>Terms</Link>
-        </ListItem>
-        <ListItem>
+        </View>
+        <View accessibilityRole="listItem">
           <Link to={new URL("/privacy", storefrontUrl).href}>Privacy</Link>
-        </ListItem>
-        <ListItem>
+        </View>
+        <View accessibilityRole="listItem">
           <Link to={new URL("/faq", storefrontUrl).href}>FAQ</Link>
-        </ListItem>
-        <ListItem>
+        </View>
+        <View accessibilityRole="listItem">
           <Link to={new URL("/accessibility", storefrontUrl).href}>
             Accessibility
           </Link>
-        </ListItem>
+        </View>
       </InlineStack>
     </InlineLayout>
   );


### PR DESCRIPTION
To make the example more accessible, adding the `accessibilityRole` to `InlineStack` to render it as an `<ol>` 

markup:
<img width="681" alt="Screenshot 2024-02-02 at 11 16 25 AM" src="https://github.com/Shopify/example-checkout--custom-footer--react/assets/82546995/a976c3f7-00b7-4436-b262-119d64bd6d20">

